### PR TITLE
Fix bibliography output for report and techreport entries

### DIFF
--- a/src/byubib.bbx
+++ b/src/byubib.bbx
@@ -1190,7 +1190,7 @@
   \newunit\newblock
   \printfield{type}%
   \setunit*{\addspace}%
-  {\myliningnumfont{}\printfield{number}}%
+  \printfield{number}%
   \newunit\newblock
   \printfield{version}%
   \newunit


### PR DESCRIPTION
Removes the undefined `\myliningnumfont{}` command in the bibliography driver for `report` and `techreport` entries. This was causing an undefined control sequence error

```tex
! Undefined control sequence.
\blx@bbx@report ...*{\addspace }{\myliningnumfont
                                                  {}\printfield {number}}\ne...
```

when displaying, for example, the entry

```bib
@techreport{Trawny2005Indirect,
address = {Minneapolis},
author = {Trawny, Nikolas and Roumeliotis, Stergios I.},
institution = {University of Minnesota, Department of Computer Science and Engineering},
number = {2005-002, Rev. 57},
title = {Indirect {Kalman} filter for {3D} attitude estimation: A tutorial for quaternion algebra},
year = 2005
}
```

This entry now displays as
![image](https://github.com/BYU-Engineering/thesis_template/assets/2702490/1820ece8-0c6b-4979-b58b-a70468b1fe8c)