### PR TITLE
Use marginnote for cited on to fix page breaks

### DIFF
--- a/src/byuthesis.cls
+++ b/src/byuthesis.cls
@@ -322,6 +322,7 @@
 % ---------------------------------------
 
 % ---------- cross referencing ------------
+\RequirePackage{marginnote}
 \RequirePackage[capitalise]{cleveref}
 % ---------------------------------------
 
@@ -555,7 +556,7 @@
 % ------------- reference margin notes for backreferencing ---------------
 % used by byubib.bbx
 \newcounter{rnote}
-\newcommand\refnote[1]{\stepcounter{rnote}\marginpar{\MakeLowercase{#1}}}
+\newcommand\refnote[1]{\stepcounter{rnote}\marginnote{\MakeLowercase{#1}}}
 
 % ---------------------------------------
 


### PR DESCRIPTION
This change uses marginnote (instead of marginpar) to print the "cite on p. ..." text in the bibliography.  Unlike marginpar that causes margin notes to float, marginnote forces the note to be exactly where marginnote was called.  This doesn't work for normal text as the margin notes will overlap, but this does work well for the backrefs in the bibliography.

marginpar is still used for the margin citations in the normal text.  